### PR TITLE
Display popout before sharing image.

### DIFF
--- a/easy-artwork.js
+++ b/easy-artwork.js
@@ -1,21 +1,32 @@
-function addButton(sheet, buttons) {
-  buttons.unshift({
+function addSheetButton(sheet, buttons) {
+	buttons.unshift({
 		class: `easy-artwork-button`,
 		icon: 'far fa-images',
 		label: 'Show Artwork',
 		onclick: (e) => {
 			const doc = sheet.document;
-
-			game.socket.emit('shareImage', {
-				image: doc.img,
-				title: doc.name,
-				uuid: doc.uuid
-			});
-
-			ui.notifications.info("Artwork shown to all other users");
+			new ImagePopout(doc.img, { title: doc.name, uuid: doc.uui }).render(true);
 		}
 	});
 }
+  
+function addPlayerShareButton(popout, buttons) {
+	if (game.user.isGM)
+	{
+		// GM Already has a share button
+		return;
+	}
 
-Hooks.on('getActorSheetHeaderButtons', addButton);
-Hooks.on('getItemSheetHeaderButtons', addButton);
+	buttons.unshift({
+		label: "JOURNAL.ActionShow",
+		class: "share-image",
+		icon: "fas fa-eye",
+		onclick: (e) => {
+			popout.shareImage();
+		}
+	});
+}
+  
+Hooks.on('getActorSheetHeaderButtons', addSheetButton);
+Hooks.on('getItemSheetHeaderButtons', addSheetButton);
+Hooks.on('getImagePopoutHeaderButtons', addPlayerShareButton);

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
   ],
   "url": "https://github.com/emdant/easy-artwork",
   "changelog": "https://github.com/emdant/easy-artwork/commits/master",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "scripts": [
     "easy-artwork.js"
   ],
@@ -18,6 +18,6 @@
   "manifest": "https://github.com/emdant/easy-artwork/releases/latest/download/module.json",
   "compatibility": {
     "minimum": "10",
-    "verified": "10"
+    "verified": "11"
   }
 }


### PR DESCRIPTION
Hello! I stumbled upon your module, I think it's very useful but I personally prefer to see the artwork before sharing it, I think it's also more uniform to what Foundry regularly offer. I did some tinkering and it should now display the popout, and add the share button for players too since normally they miss it.